### PR TITLE
Remove stream name override for metamask provider

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -194,7 +194,6 @@ class Controller {
    */
   private createPluginProvider(pluginName: string): PluginProvider {
     const pluginProvider = (new MetaMaskInpageProvider(this.rpcStream as any, {
-      jsonRpcStreamName: pluginName,
       shouldSendMetadata: false,
     }) as unknown) as Partial<PluginProvider>;
 


### PR DESCRIPTION
i think i added that to test multiple working at once in the inspector setting but it ended up breaking the actual connection in MetaMask