### PR TITLE
Added initial JSON-RPC Error support

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -180,7 +180,6 @@ class Controller {
       compartment.evaluate(sourceCode);
     } catch (err) {
       this.removePlugin(pluginName);
-      console.error(`Error while running plugin '${pluginName}'.`, err);
       throw new Error(`Error while running plugin '${pluginName}'.`);
     }
   }

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -122,8 +122,7 @@ class Controller {
         this.respond(id, {
           error: {
             code: -32603,
-            message: 'Internal JSON-RPC error.',
-            data: e.message,
+            message: `Internal JSON-RPC error: ${e.message}`,
           },
         });
       }
@@ -181,10 +180,8 @@ class Controller {
       compartment.evaluate(sourceCode);
     } catch (err) {
       this.removePlugin(pluginName);
-      console.error(
-        `Error while running plugin '${pluginName}' in worker:${self.name}.`,
-        err,
-      );
+      console.error(`Error while running plugin '${pluginName}'.`, err);
+      throw new Error(`Error while running plugin '${pluginName}'.`);
     }
   }
 


### PR DESCRIPTION
before it was just eating this error, we are now catching it and cleaning up via `this.removePlugin`, and also throwing again to ensure it goes across the wire via jsonrpc when `excutePlugin` errors.

This pr then catches it and cleans up the iframe via `terminate`: https://github.com/MetaMask/snaps-skunkworks/pull/51 