### PR TITLE
Changed controller rpc error handler to not respond twice

### DIFF
--- a/src/controller.ts
+++ b/src/controller.ts
@@ -115,9 +115,9 @@ class Controller {
         });
         return;
       }
-      let result;
       try {
-        result = await (this.methods as any)[method](...paramsAsArray);
+        const result = await (this.methods as any)[method](...paramsAsArray);
+        this.respond(id, { result });
       } catch (e) {
         this.respond(id, {
           error: {
@@ -126,7 +126,6 @@ class Controller {
           },
         });
       }
-      this.respond(id, { result });
     } else {
       this.respond(id, {
         error: new Error(`Unrecognized command: ${method}.`),

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -36,7 +36,7 @@ export const methods = (
       if (!handler) {
         throw new Error(`No RPC handler registered for plugin "${target}".`);
       }
-      return handler(requestOrigin, request) as any;
+      return handler(requestOrigin, request) as Promise<any>;
     },
   };
 };


### PR DESCRIPTION
other than not responding twice: this seems to surface a bug with json-rpc-engine when it gets `result: undefined`