### PR TITLE
Added uncaught promise rejection error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@metamask/object-multiplex": "^1.2.0",
     "@metamask/post-message-stream": "^4.0.0",
     "@open-rpc/schema-utils-js": "^1.15.0",
+    "eth-rpc-errors": "^4.0.3",
     "isomorphic-fetch": "^3.0.0",
     "json-rpc-engine": "^6.1.0",
     "pump": "^3.0.0",

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -206,7 +206,6 @@ class Controller {
     };
 
     this.pluginErrorHandler = (error: ErrorEvent) => {
-      console.log('plugin error, bubbling up', error);
       this.errorHandler(pluginName, error.message);
     };
     this.pluginPromiseErrorHandler = (error: PromiseRejectionEvent) => {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -38,9 +38,9 @@ class Controller {
 
   private methods?: IframeExecutionEnvironmentMethodMapping;
 
-  private pluginErrorHandler?: (event: any) => void;
+  private pluginErrorHandler?: (event: ErrorEvent) => void;
 
-  private pluginPromiseErrorHandler?: (event: any) => void;
+  private pluginPromiseErrorHandler?: (event: PromiseRejectionEvent) => void;
 
   constructor() {
     this.pluginRpcHandlers = new Map();

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -209,7 +209,6 @@ class Controller {
       this.errorHandler(pluginName, error.message);
     };
     this.pluginPromiseErrorHandler = (error: PromiseRejectionEvent) => {
-      console.log('plugin promise error, bubbling up', error);
       this.errorHandler(pluginName, error.reason.toString());
     };
 
@@ -225,10 +224,10 @@ class Controller {
         this.pluginPromiseErrorHandler,
       );
       window.addEventListener('error', this.pluginErrorHandler);
-    } catch (err: any) {
+    } catch (err) {
       this.removePlugin(pluginName);
       throw new Error(
-        `Error while running plugin '${pluginName}': ${err.message}`,
+        `Error while running plugin '${pluginName}': ${(err as Error).message}`,
       );
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3032,7 +3032,7 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-eth-rpc-errors@^4.0.2:
+eth-rpc-errors@^4.0.2, eth-rpc-errors@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eth-rpc-errors/-/eth-rpc-errors-4.0.3.tgz#6ddb6190a4bf360afda82790bb7d9d5e724f423a"
   integrity sha512-Z3ymjopaoft7JDoxZcEb3pwdGh7yiYMhOwm2doUt6ASXlMavpNlK6Cre0+IMl2VSGyEU9rkiperQhp5iRxn5Pg==


### PR DESCRIPTION
This adds uncaught promise rejection handling as well as notification handling.

To be able to get the pluginName that errors, it needs to create the error handler in context of the plugin start, since we are only booting 1:1 i've made it only one handler that gets overwritten 