### PR TITLE
Changed handshake back to ping

### DIFF
--- a/openrpc.json
+++ b/openrpc.json
@@ -6,11 +6,11 @@
   },
   "methods": [
     {
-      "name": "handshake",
+      "name": "ping",
       "description": "confirms that a connection has been established with the execution environment",
       "params": [],
       "result": {
-        "name": "HandshakeResult",
+        "name": "PingResult",
         "schema": {
           "$ref": "#/components/schemas/OK"
         }

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -1,8 +1,8 @@
 import Controller from './controller';
-import { ExecutePlugin, Handshake, PluginRpc } from './__GENERATED_TYPES__';
+import { ExecutePlugin, Ping, PluginRpc } from './__GENERATED_TYPES__';
 
 export interface IframeExecutionEnvironmentMethodMapping {
-  handshake: Handshake;
+  ping: Ping;
   executePlugin: ExecutePlugin;
   pluginRpc: PluginRpc;
 }
@@ -11,7 +11,7 @@ export const methods = (
   context: Controller,
 ): IframeExecutionEnvironmentMethodMapping => {
   return {
-    handshake: async () => {
+    ping: async () => {
       return 'OK';
     },
     executePlugin: async (pluginName, sourceCode) => {


### PR DESCRIPTION
This changes the `handshake` method back to `ping`, which makes more sense in the context of the lifecycle we want to achieve.


Here's a screenshot of calling `ping` on the iframe from the inspector: 

![image](https://user-images.githubusercontent.com/364566/134735490-5b64457d-6c76-4b0a-a7df-af20997a43d8.png)
