### PR TITLE
Added optional endowments param to executeSnap

### DIFF
--- a/openrpc.json
+++ b/openrpc.json
@@ -40,7 +40,7 @@
         },
         {
           "name": "endowments",
-          "description": "a list of endowments to provide to SES",
+          "description": "A list of endowments to provide to SES",
           "schema": {
             "title": "Endowments",
             "description": "An array of the names of the endowments",

--- a/openrpc.json
+++ b/openrpc.json
@@ -40,7 +40,7 @@
         },
         {
           "name": "endowments",
-          "description": "a list off endowments to provide to SES",
+          "description": "a list of endowments to provide to SES",
           "schema": {
             "title": "Endowments",
             "description": "An array of the names of the endowments",

--- a/openrpc.json
+++ b/openrpc.json
@@ -37,6 +37,19 @@
             "title": "SourceCode",
             "type": "string"
           }
+        },
+        {
+          "name": "endowments",
+          "description": "a list off endowments to provide to SES",
+          "schema": {
+            "title": "Endowments",
+            "description": "An array of the names of the endowments",
+            "type": "array",
+            "items": {
+              "title": "Endowment",
+              "type": "string"
+            }
+          }
         }
       ],
       "result": {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -214,7 +214,6 @@ class Controller {
       console, // Adding raw console for now
       crypto: window.crypto,
       Date,
-      // fetch: window.fetch.bind(window),
       Math, // Math.random is considered unsafe, but we need it
       setTimeout,
       SubtleCrypto: window.SubtleCrypto,

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -12,11 +12,7 @@ import EEOpenRPCDocument from '../openrpc.json';
 import { STREAM_NAMES } from './enums';
 
 import { IframeExecutionEnvironmentMethodMapping, methods } from './methods';
-import {
-  Endowments,
-  JSONRPCRequest,
-  StringDoaGddGA,
-} from './__GENERATED_TYPES__';
+import { Endowments, JSONRPCRequest } from './__GENERATED_TYPES__';
 import { sortParamKeys } from './helpers/sortParams';
 
 type SnapRpcHandler = (
@@ -228,10 +224,11 @@ class Controller {
           throw new Error(`Unknown endowment: "${_endowment}".`);
         }
 
-        
-        endowments[_endowment] = typeof globalValue === 'function'
-          ? globalValue.bind(window)
-          : globalValue;
+        const globalValue = (window as any)[_endowment];
+        endowments[_endowment] =
+          typeof globalValue === 'function'
+            ? globalValue.bind(window)
+            : globalValue;
       });
     }
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -12,7 +12,11 @@ import EEOpenRPCDocument from '../openrpc.json';
 import { STREAM_NAMES } from './enums';
 
 import { IframeExecutionEnvironmentMethodMapping, methods } from './methods';
-import { JSONRPCRequest } from './__GENERATED_TYPES__';
+import {
+  Endowments,
+  JSONRPCRequest,
+  StringDoaGddGA,
+} from './__GENERATED_TYPES__';
 import { sortParamKeys } from './helpers/sortParams';
 
 type SnapRpcHandler = (
@@ -184,9 +188,13 @@ class Controller {
    * @param {Array<string>} approvedPermissions - The snap's approved permissions.
    * Should always be a value returned from the permissions controller.
    * @param {string} sourceCode - The source code of the snap, in IIFE format.
-   * @param {Object} ethereumProvider - The snap's Ethereum provider object.
+   * @param {Array} endowments - An array of the names of the endowments.
    */
-  public startSnap(snapName: string, sourceCode: string) {
+  public startSnap(
+    snapName: string,
+    sourceCode: string,
+    _endowments: Endowments,
+  ) {
     console.log(`starting snap '${snapName}' in worker`);
     if (this.snapPromiseErrorHandler) {
       window.removeEventListener(
@@ -200,13 +208,13 @@ class Controller {
 
     const wallet = this.createSnapProvider(snapName);
 
-    const endowments = {
+    const endowments: Record<string, any> = {
       BigInt,
       Buffer,
       console, // Adding raw console for now
       crypto: window.crypto,
       Date,
-      fetch: window.fetch.bind(window),
+      // fetch: window.fetch.bind(window),
       Math, // Math.random is considered unsafe, but we need it
       setTimeout,
       SubtleCrypto: window.SubtleCrypto,
@@ -214,6 +222,12 @@ class Controller {
       WebSocket,
       XMLHttpRequest,
     };
+
+    if (_endowments && _endowments.length > 0) {
+      _endowments.forEach((_endowment) => {
+        endowments[_endowment] = (window as any)[_endowment].bind(window);
+      });
+
 
     this.snapErrorHandler = (error: ErrorEvent) => {
       this.errorHandler(error.error, { snapName });

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -228,7 +228,6 @@ class Controller {
         endowments[_endowment] = (window as any)[_endowment].bind(window);
       });
 
-
     this.snapErrorHandler = (error: ErrorEvent) => {
       this.errorHandler(error.error, { snapName });
     };

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -225,7 +225,14 @@ class Controller {
 
     if (_endowments && _endowments.length > 0) {
       _endowments.forEach((_endowment) => {
-        endowments[_endowment] = (window as any)[_endowment].bind(window);
+        if (!(_endowment in window)) {
+          throw new Error(`Unknown endowment: "${_endowment}".`);
+        }
+
+        
+        endowments[_endowment] = typeof globalValue === 'function'
+          ? globalValue.bind(window)
+          : globalValue;
       });
     }
 

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -214,8 +214,6 @@ class Controller {
       setTimeout,
       SubtleCrypto: window.SubtleCrypto,
       wallet,
-      WebSocket,
-      XMLHttpRequest,
     };
 
     if (_endowments && _endowments.length > 0) {

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -227,6 +227,7 @@ class Controller {
       _endowments.forEach((_endowment) => {
         endowments[_endowment] = (window as any)[_endowment].bind(window);
       });
+    }
 
     this.snapErrorHandler = (error: ErrorEvent) => {
       this.errorHandler(error.error, { snapName });

--- a/src/methods.ts
+++ b/src/methods.ts
@@ -14,7 +14,7 @@ export const methods = (
     ping: async () => {
       return 'OK';
     },
-    executeSnap: async (snapName, sourceCode) => {
+    executeSnap: async (snapName, sourceCode, endowments) => {
       if (snapName === undefined) {
         throw new Error('snapName is not defined');
       }
@@ -27,7 +27,7 @@ export const methods = (
       if (typeof sourceCode !== 'string') {
         throw new Error('sourceCode is not a string');
       }
-      context.startSnap(snapName as string, sourceCode as string);
+      context.startSnap(snapName as string, sourceCode as string, endowments);
       return 'OK';
     },
     snapRpc: async (target, requestOrigin, request) => {


### PR DESCRIPTION
This adds an optional `endowments` parameter to `executeSnap` to allow access to globals like `fetch` per snap.

##### Example with `fetch` endowment
![image](https://user-images.githubusercontent.com/364566/145901378-b23a4e48-1e91-4f61-aed7-3a6d8be8c817.png)

![image](https://user-images.githubusercontent.com/364566/145901420-07e6808c-1c34-475f-8046-843aaca7b27d.png)

##### Example with no endowments:
![image](https://user-images.githubusercontent.com/364566/145901929-8443a81b-637b-406c-921d-e7ac2419c183.png)
