### PR TITLE
@metamask/execution-environments@0.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "start": "node scripts/start.js"
   },
   "dependencies": {
-    "@metamask/execution-environments": "^0.10.0",
+    "@metamask/execution-environments": "^0.10.4",
     "ses": "^0.15.11"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -647,15 +647,15 @@
   resolved "https://registry.yarnpkg.com/@metamask/eslint-config/-/eslint-config-7.0.1.tgz#eeb87baa902965ca7931c26911d7027373706f34"
   integrity sha512-dMZ+iyZrHdZK0D1uStTx8UN6Q6IK9YGbqPUwxgTj63M0mZOsuqs8qpGf+9Dn7uqS+8Oe9jNqejKxozjTiJvsEw==
 
-"@metamask/execution-environments@^0.10.0":
-  version "0.10.2"
-  resolved "https://registry.yarnpkg.com/@metamask/execution-environments/-/execution-environments-0.10.2.tgz#dfa4750a0eee4f51d9bc7e3c75a0e80a18798093"
-  integrity sha512-4bqDTk0oPRiju21M8KNaoxT8eiGaygyC2pldIrCDByfDqiIVkIpv8neol6EEH7ebMQkNiC4sr8IhfNFL7cJIdA==
+"@metamask/execution-environments@^0.10.4":
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/@metamask/execution-environments/-/execution-environments-0.10.4.tgz#aef543b3c49bb8807476e5eb0ee14cc1b5e9c77c"
+  integrity sha512-pfs+8d59GQPMg+8gXdhNmAHe5jeTvNe+roKCikL3fhWvoBl0tUuh6jRgC0xzxTnI/UG7W23SSc2G/qrh1/Dekg==
   dependencies:
     "@metamask/object-multiplex" "^1.2.0"
     "@metamask/post-message-stream" "^4.0.0"
     "@metamask/providers" "^8.1.1"
-    "@metamask/snap-types" "^0.10.1"
+    "@metamask/snap-types" "^0.10.3"
     cross-fetch "^3.1.5"
     eth-rpc-errors "^4.0.3"
     pump "^3.0.0"
@@ -706,10 +706,10 @@
   resolved "https://registry.yarnpkg.com/@metamask/safe-event-emitter/-/safe-event-emitter-2.0.0.tgz#af577b477c683fad17c619a78208cede06f9605c"
   integrity sha512-/kSXhY692qiV1MXu6EeOZvg5nECLclxNXcKCxJ3cXQgYuRymRHpdx/t7JXfsK+JLjwA1e1c1/SBrlQYpusC29Q==
 
-"@metamask/snap-types@^0.10.1":
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/@metamask/snap-types/-/snap-types-0.10.1.tgz#dd170813d38091473f9ae1fd1e9d64c46666ba0c"
-  integrity sha512-DsTAMSNmVWH/wXL4OWvnI4Wxh247d7PPD0jjxlMC3hEKB6hSdbCW3umwxqBCxgrU18gJOGwNJMygTolxO0SUrA==
+"@metamask/snap-types@^0.10.3":
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/@metamask/snap-types/-/snap-types-0.10.3.tgz#733cbba058489eb084590788e9d9ad1eeff2a35a"
+  integrity sha512-Rdus61liExENanzBtu9QYRScyqzOQGvXuaaZJAVJN5TnsIt2hsOq9D6wktKvT3IHeKCF9ydFq4YWam2RcNccoQ==
   dependencies:
     "@metamask/controllers" "^26.0.0"
 


### PR DESCRIPTION
Updates `@metamask/execution-environments` from `0.10.0` to `0.10.4`, fixing a critical bug.