### PR TITLE
Update deploy workflow to use `personal_token` instead of `github_token`

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -32,6 +32,6 @@ jobs:
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
         uses: peaceiris/actions-gh-pages@de7ea6f8efb354206b205ef54722213d99067935
         with:
-          github_token: ${{ secrets.METAMASKBOT_TOKEN }}
+          personal_token: ${{ secrets.METAMASKBOT_TOKEN }}
           publish_dir: ./public
           destination_dir: ${{ inputs.destination_dir }}


### PR DESCRIPTION
From [`actions-gh-pages`' docs](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-set-runners-access-token-github_token):

> This option is for GITHUB_TOKEN, not a personal access token.

We have to use `personal_token` instead.